### PR TITLE
add TOCs to API pages

### DIFF
--- a/docs-phonegap/en/edge/guide/phonegap-build/api/read.md
+++ b/docs-phonegap/en/edge/guide/phonegap-build/api/read.md
@@ -27,6 +27,17 @@ for write methods.
 Please note that example responses are formatted for the sake of
 legibility. Actual JSON responses will have no significant whitespace.
 
+The API's read interface includes the following:
+
+* GET https://build.phonegap.com/api/v1/me
+* GET https://build.phonegap.com/api/v1/apps
+* GET https://build.phonegap.com/api/v1/apps/:id
+* GET https://build.phonegap.com/api/v1/apps/:id/icon
+* GET https://build.phonegap.com/api/v1/apps/:id/:platform
+* GET https://build.phonegap.com/api/v1/keys
+* GET https://build.phonegap.com/api/v1/keys/:platform
+* GET https://build.phonegap.com/api/v1/keys/:platform/:id
+
 ## GET https://build.phonegap.com/api/v1/me
 
 Get a JSON-encoded representation of the authenticated user, as well

--- a/docs-phonegap/en/edge/guide/phonegap-build/api/version0.md
+++ b/docs-phonegap/en/edge/guide/phonegap-build/api/version0.md
@@ -21,12 +21,31 @@ license: Licensed to the Apache Software Foundation (ASF) under one
 # The PhoneGap Build API, Version 0
 
 Version 0 (v0) of the API is a preview release for the beta version of
-PhoneGap Build. Although available for existing clients, it will not
-receive any further updates. If you are developing a new application
-accessing PhoneGap Build, see version 1 of The PhoneGap Build API.
+PhoneGap Build. Although available for legacy applications, it will
+not receive any further updates. If you are developing a new
+application accessing PhoneGap Build, see version 1 of The PhoneGap
+Build API.
 
 Version 0 authenticates through HTTPS with basic authentication.  All
 unauthenticated requests return a `401` (unauthorized) status code.
+
+The read API features:
+
+* GET https://build.phonegap.com/api/v0/me
+* GET https://build.phonegap.com/api/v0/apps
+* GET https://build.phonegap.com/api/v0/apps/:id
+* GET https://build.phonegap.com/api/v0/apps/:id/:icon
+* GET https://build.phonegap.com/api/v0/apps/:id/:platform
+* GET https://build.phonegap.com/api/v0/keys/
+
+The write API features:
+
+* POST https://build.phonegap.com/api/v0/apps
+* POST https://build.phonegap.com/api/v0/apps/:id/:icon
+* POST https://build.phonegap.com/api/v0/apps/:id/push
+* PUT https://build.phonegap.com/api/v0/apps/:id
+* POST https://build.phonegap.com/api/v0/keys/:platform
+* DELETE https://build.phonegap.com/api/v0/apps/:id
 
 ## JSON
 

--- a/docs-phonegap/en/edge/guide/phonegap-build/api/write.md
+++ b/docs-phonegap/en/edge/guide/phonegap-build/api/write.md
@@ -29,11 +29,24 @@ file uploads. API requests should have the content type
 `multipart/form-data`, and bodies of JSON requests should be named
 `data`.
 
+The API's write interface includes the following:
+
+* POST https://build.phonegap.com/api/v1/apps
+* PUT https://build.phonegap.com/api/v1/apps/:id
+* POST https://build.phonegap.com/api/v1/apps/:id/icon
+* POST https://build.phonegap.com/api/v1/apps/:id/build
+* POST https://build.phonegap.com/api/v1/apps/:id/build/:platform
+* POST https://build.phonegap.com/api/v1/apps/:id/collaborators
+* PUT https://build.phonegap.com/api/v1/apps/:id/collaborators/:id
+* POST https://build.phonegap.com/api/v1/keys/:platform
+* PUT https://build.phonegap.com/api/v1/keys/:platform/:id
+* DELETE https://build.phonegap.com/api/v1/apps/:id
+* DELETE https://build.phonegap.com/api/v1/apps/:id/collaborators/:id
+* DELETE https://build.phonegap.com/api/v1/keys/:platform/:id
+
 ## POST https://build.phonegap.com/api/v1/apps
 
-Create a new app.
-
-### Required parameters
+Creates a new app. Required parameters:
 
 * __title__: You must specify a title for your app. Any title
   specified in your package's `config.xml` takes precedence.
@@ -45,7 +58,7 @@ Create a new app.
 
   * __remote_repo__: You have a remote repository with your app content
 
-### Optional parameters
+Optional parameters:
 
 * __package__: Sets your app's package identifier. This can be
   modified after the app's creation, or in your `config.xml` file.
@@ -488,7 +501,7 @@ A simpler URL to build for a single platform:
 Add a collaborator to work with you on a given application. You must
 be the app's owner/admin to do so.
 
-### Required parameters
+Required parameters:
 
 * __email__: The email address of your new collaborator.
 


### PR DESCRIPTION
doc is lengthy, so provide list of links to each API method. Also, demote some headings
