### PR TITLE
Remove redundant word.

### DIFF
--- a/docs/1-getting-started/4-run-your-app/2-cli.html.md
+++ b/docs/1-getting-started/4-run-your-app/2-cli.html.md
@@ -43,7 +43,7 @@ The PhoneGap CLI starts a small web server to host your project and returns the 
   <img class="mobile-image" src="/images/dev-app-success.jpg"/>
 
 
- Once the PhoneGap Developer app loads connects and loads your mobile application, it should be displayed for preview as shown below:
+ Once the PhoneGap Developer app connects and loads your mobile application, it should be displayed for preview as shown below:
 
  <img class="mobile-image" src="/images/dev-app-preview.jpg"/>
 


### PR DESCRIPTION
This fixes a typo in step 4.