### PR TITLE
Wrong option on the menu located on PhoneGap Developer docs, Install section

### DIFF
--- a/docs/3-references/developer-app/1-install/1-ios.html.md
+++ b/docs/3-references/developer-app/1-install/1-ios.html.md
@@ -5,7 +5,7 @@ github_url: https://github.com/phonegap/phonegap-docs/blob/master/docs/3-referen
 layout: subpage
 expand: dev-app
 tabs:
-  - label: Mac
+  - label: iOS
     url: references/developer-app/install/ios
   - label: Android
     url: references/developer-app/install/android

--- a/docs/3-references/developer-app/1-install/2-android.html.md
+++ b/docs/3-references/developer-app/1-install/2-android.html.md
@@ -5,7 +5,7 @@ github_url: https://github.com/phonegap/phonegap-docs/blob/master/docs/3-referen
 layout: subpage
 expand: dev-app
 tabs:
-  - label: Mac
+  - label: iOS
     url: references/developer-app/install/ios
   - label: Android
     url: references/developer-app/install/android

--- a/docs/3-references/developer-app/1-install/3-win.html.md
+++ b/docs/3-references/developer-app/1-install/3-win.html.md
@@ -5,7 +5,7 @@ github_url: https://github.com/phonegap/phonegap-docs/blob/master/docs/3-referen
 layout: subpage
 expand: dev-app
 tabs:
-   - label: Mac
+   - label: iOS
      url: references/developer-app/install/ios
    - label: Android
      url: references/developer-app/install/android


### PR DESCRIPTION
The first option on the menu located on PhoneGap Developer docs,
Install section is wrong, it says Mac, but it should be iOS