### PR TITLE
fixed most broken links

### DIFF
--- a/docs/3-references/phonegap-build/configuring/plugins.html.md
+++ b/docs/3-references/phonegap-build/configuring/plugins.html.md
@@ -20,21 +20,21 @@ There are two steps to including a plugin in your project:
 1. <a href="#importing-config">Importing the native code using the config.xml</a>
 2. <a href="#importing-native">Referencing the JavaScript code for the plugin</a>
 
-<a id="importing-config"></a>
+<a class="anchor" id="importing-config"></a>
 #### Importing the native code
 
 To import the native code into your PhoneGap Build project, you will need to add the correct `<plugin>` or deprecated `<gap:plugin>` tag to your config.xml file.
 
-<b>If you omit the `spec` (or `version`) tag of a npm or PhoneGap Build plugin, your app will always be built with the latest version of the plugin. It will be updated automatically the next time you update your application code after a plugin is updated, which may cause unexpected behaviour.</b> For more info on plugin versioning, <a href="#plugin-versions">click here</a>.
+<b>If you omit the `spec` (or `version`) tag of a npm or PhoneGap Build plugin, your app will always be built with the latest version of the plugin. It will be updated automatically the next time you update your application code after a plugin is updated, which may cause unexpected behavior.</b> For more info on plugin versioning, <a href="#plugin-version">click here</a>.
 
 - [&lt;plugin&gt; tag](#plugin)
 - [&lt;gap:plugin&gt; tag](#gap-plugin)
 - [Plugin source](#plugin-source)
 - [Plugin version/location](#plugin-version)
-- [Plugin parameters](#plugin-parameters)
+- [Plugin parameters](#plugin-params)
 - [Usage example](#usage-example)
 
-<a id="plugin"></a>
+<a class="anchor" id="plugin"></a>
 #### &lt;plugin&gt;
 
 - **name**: Plugins should be referenced by the plugin ID which is normally in a reverse domain format (ex: com.phonegap.plugins.barcodescanner). Optional if the plugin is git-backed.
@@ -42,7 +42,7 @@ To import the native code into your PhoneGap Build project, you will need to add
 - **source**: Optional, can either be "pgb", "npm" or "git".  Defaults to "npm" (or "git" if a git URL is detected).
 - **params**: Plugins may require parameters for configuration properties. <a href="#plugin-params">Here is a detailed explanation.</a>
 
-<a id="gap-plugin"></a>
+<a class="anchor" id="gap-plugin"></a>
 #### &lt;gap:plugin&gt;
 
 - **name**: Plugins should be referenced by the plugin ID which is normally in a reverse domain format (ex: com.phonegap.plugins.barcodescanner).
@@ -50,7 +50,7 @@ To import the native code into your PhoneGap Build project, you will need to add
 - **source**: Optional, can either be `pgb`, `npm` or `git`.  Defaults to `pgb` (or `git` if a git URL is detected).
 - **params**: Plugins may require parameters for configuration properties. <a href="#plugin-params">Here is a detailed explanation.</a>
 
-<a id="plugin-sources"></a>
+<a class="anchor" id="plugin-source"></a>
 #### Plugin Source
 
 Plugins can be included from either our repository, located <a href="https://build.phonegap.com/plugins">here</a>, at <a href="https://www.npmjs.com/">npm</a> or from a public git repository.
@@ -71,7 +71,7 @@ To include a plugin from the PhoneGap Build <a href="https://build.phonegap.com/
 
 The param fragments are handled identically regardless of the source of the plugin.
 
-<a id="plugin-versions"></a>
+<a class="anchor" id="plugin-version"></a>
 #### Plugin Version / Location
 
 Here is the most simplistic way of using a versioned plugin. The `spec` attribute is the recommended way to specify the version. `spec` is used so as to be compatibile with the Cordova CLI, which uses a `spec` attribute to describe the version or location of the plugin.
@@ -100,7 +100,7 @@ And finally, this version tag:
 
 would load the latest 2.2.x version so long as x is greater or equal to 3.
 
-<a id="plugin-params"></a>
+<a class="anchor" id="plugin-params"></a>
 #### Plugin Parameters
 
 Plugins may require configuration information to be present; this can be done with adding <param> children to the <plugin> tag:
@@ -112,6 +112,7 @@ Plugins may require configuration information to be present; this can be done wi
 
 <i class="glyphicon glyphicon-check"></i> Make sure to check the documentation of the plugin to see if parameters are necessary.
 
+<a class="anchor" id="usage-example"></a>
 #### Usage Example
 
 Here is a config.xml that includes the Barcode Scanner plugin from npm as an example:
@@ -138,7 +139,7 @@ Here is a config.xml that includes the Barcode Scanner plugin from npm as an exa
         <plugin name="phonegap-plugin-barcodescanner" />
     </widget>
 
-<a id="importing-native"></a>
+<a class="anchor" id="importing-native"></a>
 ### Referencing the JavaScript code
 
 If a plugin utilizes the <code>js-module</code> element to direct cordova to load the plugin javascripts, then no <code>&lt;script&gt;</code> references will be necessary to load a plugin. This is the case for the core cordova plugins, but 3rd party plugins will be implementation-dependent. Refer to the plugin's documentation to determine if you'll need to manually include the javascript.

--- a/docs/3-references/phonegap-build/debugging/weinre.html.md
+++ b/docs/3-references/phonegap-build/debugging/weinre.html.md
@@ -114,7 +114,7 @@ To start your new local Weinre instance run the following command:
 You will now see output like the following:
 
     Hardeeps-MacBook-Air:~ hardeep$ weinre
-    2013-07-01T20:03:34.890Z weinre: starting server at http://localhost:8080
+    2013-07-01T20:03:34.890Z weinre: starting server at `http://localhost:8080`
 
 Weinre is now up and running! If you are running this behind a router that uses NAT you will need to find your IP address. You will use this IP when specifying your configuration with Build.
 
@@ -132,10 +132,8 @@ Now include a reference to the Weinre debug script on your debug server, like so
 
 __I can't connect to my Local Server__
 
-First of all make sure that your server is running. Chances are if you're using the default configuration you can visit http://localhost:8080 and it should be responding.
+First of all make sure that your server is running. Chances are if you're using the default configuration you can visit `http://localhost:8080` and it should be responding.
 
 If this works it's most likely the IP address you're providing to Build; please verify that it is correct. A google search such as `windows [version] find ip address` or `OSX [version] find ip address` will help you find articles on getting the right ip.
 
-Assuming that you're using a router running NAT verify that you can visit it within your network by visiting http://[ip address]:8080.
-
-
+Assuming that you're using a router running NAT verify that you can visit it within your network by visiting `http://[ip address]:8080`.

--- a/docs/3-references/phonegap-build/developer-api/write.html.md
+++ b/docs/3-references/phonegap-build/developer-api/write.html.md
@@ -84,7 +84,7 @@ The API's write interface includes the following:
 
 <a class="api info" href="#_post_https_build_phonegap_com_api_v1_keys_platform"><span>POST</span><code>/api/v1/keys/:platform</code> Add a Signing Key for A Specific Platform</a>
 
-<a class="api primary" href="#_put_https_build_phonegap_com_api_v1_keys_platform"><span>PUT</span><code>/api/v1/keys/:platform/:id</code> Update/Unlock a Singing Key for a Specific Platform</a>
+<a class="api primary" href="#-put-https-build-phonegap-com-api-v1-keys-platform-id-"><span>PUT</span><code>/api/v1/keys/:platform/:id</code> Update/Unlock a Singing Key for a Specific Platform</a>
 
 <a class="api danger" href="#_delete_https_build_phonegap_com_api_v1_apps_id"><span>DELETE</span><code>/api/v1/apps/:id</code> Delete an App</a>
 
@@ -550,7 +550,7 @@ Once the builds are queued, you will want to watch the results of `GET
 `pending` to either `complete` or `error`.
 
 <span id="_post_https_build_phonegap_com_api_v1_apps_id_build_platform"></span>
-### `POST https://build.phonegap.com/api/v1/apps/:id/build/:platform
+### `POST https://build.phonegap.com/api/v1/apps/:id/build/:platform`
 
 A simpler URL to build for a single platform:
 
@@ -671,7 +671,7 @@ The following are required for iOS builds:
 * a title for your certificate-profile pair
 
 Details on how to obtain these files are in our [iOS
-Signing](/docs/ios-builds) documentation.
+Signing](/references/phonegap-build/signing/ios) documentation.
 
 A sample post would look like this:
 
@@ -702,7 +702,7 @@ The following are required for Android builds:
 * a title for your key
 
 Details on how to get your keystore file and the associated data are
-available in our [Android Code Signing](/docs/android-signing)
+available in our [Android Code Signing](/references/phonegap-build/signing/android)
 documentation.
 
 Here is a sample post:

--- a/docs/3-references/phonegap-build/getting-started.html.md
+++ b/docs/3-references/phonegap-build/getting-started.html.md
@@ -7,10 +7,10 @@ expand: build
 
 1. [What Do I Upload?](#what_do_i_upload)
 2. [How Do I Configure My Application?](#configure_application)
-3. [What's Next?](#whats_next)
-3. [Where can I Get Help?](#help)
+3. [How Do I Structure My Application?](#structure_application)
+4. [Where can I Get Help?](#help)
 
-<a id="what_do_i_upload"></a>
+<a class="anchor" id="what_do_i_upload"></a>
 ### 1. What Do I Upload?
 
 #### Preparing the Assets
@@ -25,12 +25,12 @@ PhoneGap Build will inject `phonegap.js`, `cordova.js` (identical sources), and 
 
 For maximum sizes of zip uploads, see the <a href="https://build.phonegap.com/plans">plans page</a>.
 
-<a id="configure_application"></a>
+<a class="anchor" id="configure_application"></a>
 ### 2. How Do I Configure My Application?
 
 You'll need an application configuration file, or `config.xml`, in your app package to configure how your app is built. This includes PhoneGap version, icons and splash screens, platforms, and much more. [See this page for a breakdown of PhoneGap versions supported by PhoneGap Build](https://build.phonegap.com/current-support). See the [configuration section](../configuring/) for more on the config.xml file.
 
-<a id="structure_application"></a>
+<a class="anchor" id="structure_application"></a>
 ### 3. How Do I Structure My Application?
 
 PhoneGap Build's only requirement for your application structure is that the `config.xml` and `index.html` is in the top level of your application.  Other than that
@@ -47,7 +47,7 @@ A typical use case is for a directory containing the icons and splashcreens for 
 
 Please note that the `.pgbomit` file is a placeholder file only, it is not read and its only function is to highlight a directory.  It is *not* like .gitignore or other file types that can contain patterns.
 
-<a id="help"></a>
+<a class="anchor" id="help"></a>
 ### 4. Where can I get help?
 
 Please search all communication channels prior to posting questions to help us reduce repetition and keep the forums useful and efficient! Here's some channels:
@@ -55,4 +55,4 @@ Please search all communication channels prior to posting questions to help us r
 - Search our old [community forum](https://community.phonegap.com)
 - For help on developing your application (plugins, APIs, platform quirks, etc), see the [Adobe PhoneGap Forum](https://forums.adobe.com/community/phonegap/)
 - For help specifically using the PhoneGap Build Service (website, API, build errors), post to the [Adobe PhoneGap Build Forum](https://forums.adobe.com/community/phonegap/)
-- [Stackoverflow](www.stackoverflow.com)
+- [Stackoverflow](http://www.stackoverflow.com)

--- a/docs/3-references/phonegap-build/signing/windows.html.md
+++ b/docs/3-references/phonegap-build/signing/windows.html.md
@@ -11,7 +11,7 @@ expand: build-signing
 <a id="windows"></a>
 ### Windows 10 (Universal) Signing
 
-Windows builds have a slightly more involved signing process than the previous Windows Phone Publisher ID method, which was a simple GUID setting. A .pfx certificate file is now required to sign your app and distribute it to the App Store. [This article on MSDN](https://msdn.microsoft.com/en-us/library/windows/desktop/jj835832(v=vs.85).aspx) explains how to create a PFX store file. Ensure the Subject Name of your signing certificate matches the Windows Publisher ID from your [Microsoft Developer Account](https://developer.microsoft.com/en-us/dashboard/account/management).
+Windows builds have a slightly more involved signing process than the previous Windows Phone Publisher ID method, which was a simple GUID setting. A .pfx certificate file is now required to sign your app and distribute it to the App Store. [This article on MSDN](https://msdn.microsoft.com/en-us/library/windows/desktop/jj835832%28v=vs.85%29.aspx) explains how to create a PFX store file. Ensure the Subject Name of your signing certificate matches the Windows Publisher ID from your [Microsoft Developer Account](https://developer.microsoft.com/en-us/dashboard/account/management).
 
 Go to your [PhoneGap Build Account Settings](https://buildstage.phonegap.com/people/edit), select the **Signing Keys** tab, upload your **Windows 10** pfx key and unlock it, and select it when building your application.
 
@@ -22,7 +22,7 @@ Go to your [PhoneGap Build Account Settings](https://buildstage.phonegap.com/peo
     ```&lt;author&gt;Adobe Systems Canada Inc&lt;/author&gt;```
 
 2. A new config.xml preference `windows-identity-name` has been introduced to set the App Idenity Name in your App Manifest. This preference must match the App Identity Name from your *Windows Dev Center Account -> App Management -> App Identity*:
-	
+
 	```&lt;preference name="windows-identity-name" value="PhonegapBuild.PGBDeveloper" /&gt;```
 
 <a id="winphone8"></a>
@@ -34,4 +34,3 @@ Go to your [PhoneGap Build Account Settings](https://buildstage.phonegap.com/peo
 4. Add the Publisher ID to your Signing Keys in your [PhoneGap Build Account Settings](https://build.phonegap.com/people/edit).
 5. Build your app using the newly added Windows Publisher ID, selected in a dropdown in your App details.
 6. Upload the resulting xap/appx file to the Windows Dev Center.
-


### PR DESCRIPTION
There is just one link left breaking the html-proofer tests on https://github.com/phonegap/phonegap-docs/blob/phonegap-build-docs-squashed/docs/3-references/phonegap-build/configuring/plugins.html.md

`[Contributing Plugins ](developer_contributing_plugins.md.html)` points to a file that doesn't exist and I didn't see an obvious counterpart on the new build docs.