### PR TITLE
Update ios-custom-build.html.md

### DIFF
--- a/docs/3-references/developer-app/6-custom-build/ios-custom-build.html.md
+++ b/docs/3-references/developer-app/6-custom-build/ios-custom-build.html.md
@@ -35,6 +35,7 @@ element, modify the `id` attribute to set your own unique app bundle id.
 
 4. Run the `build` command for iOS on the command line in the root of the project:  
 
+        $ cordova platform add ios
         $ cordova build ios
 
   <div class='alert--warning'>At this point the build may fail with code signing errors due to provisioning if it did not associate your app id with one of your


### PR DESCRIPTION
Fixes "Error: No platforms added to this project. Please use `cordova platform add <platform>`." when running cordova build ios