### PR TITLE
Updated ® symbol to HTML entity

### DIFF
--- a/docs/4-phonegap-build/3-signing/1-ios.html.md
+++ b/docs/4-phonegap-build/3-signing/1-ios.html.md
@@ -27,7 +27,7 @@ tabs:
 
 You'll first need to obtain an Apple Developer Certificate. See apple documenation for this.
 
-Next you'll export it to the P12 keystore format. To do this on Mac® OS:
+Next you'll export it to the P12 keystore format. To do this on Mac&reg; OS:
 
 1. Open the Keychain Access application (in the Applications/Utilities folder).
 1. If you have not already added the certificate to Keychain, select File > Import. Then navigate to the certificate file (the .cer file) you obtained from Apple.


### PR DESCRIPTION
Weird rendering of the ® symbol in browsers, therefore have changed it to the HTML entity so should always display correctly.
![screen shot 2016-10-21 at 15 55 43](https://cloud.githubusercontent.com/assets/4706739/19603071/aba4f9de-97a7-11e6-86a8-2d2c5ea472d5.png)
