### PR TITLE
Adding iPad Pro Icon Info

### DIFF
--- a/docs/4-phonegap-build/2-configuring/icons-and-splash.html.md
+++ b/docs/4-phonegap-build/2-configuring/icons-and-splash.html.md
@@ -65,6 +65,7 @@ The names below reflect the names of the destination files when they are added t
 <!-- iPad -->
 <icon src="icon-76.png" platform="ios" width="76" height="76" />
 <icon src="icon-76@2x.png" platform="ios" width="152" height="152" />
+<icon src="icon-83.5@2x.png" platform="ios" width="167" height="167" />
 
 <!-- Settings Icon -->
 <icon src="icon-small.png" platform="ios" width="29" height="29" />


### PR DESCRIPTION
iPad Pro App Icon for Retina display (@2x)