### PR TITLE
:memo: 'notification' event not fired in foreground (Android/Phonegap…

### DIFF
--- a/docs/2-tutorials/2-develop/6-push-notifications.html.md
+++ b/docs/2-tutorials/2-develop/6-push-notifications.html.md
@@ -111,16 +111,16 @@ Starting with **PhoneGap CLI** release 6.2.0 and **PhoneGap Developer App** rele
   $ phonegap push --deviceID APA91bE1MmeTc92igNoi5OkDWUV --service apns --payload "{ \"aps\": { \"alert\": \"Hello World\" } }"
   ```
 
-  or enter the following command if you are testing on Android or Browser:
+  or enter the following command if you are testing on Android or Browser (If you are running PhoneGap CLI 6.5.0 or earlier replace `--service fcm` with `--service gcm`):
 
   MacOS:
   ```sh
-  $ phonegap push --deviceID APA91bE1MmeTc92igNoi5OkDWUV --service gcm --payload '{ "data": { "title": "Hello", "message": "World"} }'
+  $ phonegap push --deviceID APA91bE1MmeTc92igNoi5OkDWUV --service fcm --payload '{ "data": { "title": "Hello", "message": "World"} }'
   ```
 
   Windows:
   ```sh
-  $ phonegap push --deviceID APA91bE1MmeTc92igNoi5OkDWUV --service gcm --payload "{ \"data\": { \"title\": \"Hello\", \"message\": \"World\"} }"
+  $ phonegap push --deviceID APA91bE1MmeTc92igNoi5OkDWUV --service fcm --payload "{ \"data\": { \"title\": \"Hello\", \"message\": \"World\"} }"
   ```
 
   replacing the deviceID with the one you received from the registration event in the previous step.
@@ -147,16 +147,16 @@ Starting with **PhoneGap CLI** release 6.2.0 and **PhoneGap Developer App** rele
   $ phonegap push --deviceID APA91bE1MmeTc92igNoi5OkDWUV --service apns --payload "{ \"aps\": { \"alert\": \"Hello World\" } }"
   ```
 
-  or enter the following command if you are testing on Android or Browser:
+  or enter the following command if you are testing on Android or Browser (If you are running PhoneGap CLI 6.5.0 or earlier replace `--service fcm` with `--service gcm`):
 
   MacOS:
   ```sh
-  $ phonegap push --deviceID APA91bE1MmeTc92igNoi5OkDWUV --service gcm --payload '{ "data": { "title": "Hello", "message": "World"} }'
+  $ phonegap push --deviceID APA91bE1MmeTc92igNoi5OkDWUV --service fcm --payload '{ "data": { "title": "Hello", "message": "World"} }'
   ```
 
   Windows:
   ```sh
-  $ phonegap push --deviceID APA91bE1MmeTc92igNoi5OkDWUV --service gcm --payload "{ \"data\": { \"title\": \"Hello\", \"message\": \"World\"} }"
+  $ phonegap push --deviceID APA91bE1MmeTc92igNoi5OkDWUV --service fcm --payload "{ \"data\": { \"title\": \"Hello\", \"message\": \"World\"} }"
   ```
 
   replacing the deviceID with the one you received from the registration event in the previously.
@@ -179,16 +179,16 @@ Starting with **PhoneGap CLI** release 6.2.0 and **PhoneGap Developer App** rele
   $ phonegap push --deviceID APA91bE1MmeTc92igNoi5OkDWUV --service apns --payload "{ \"aps\": { \"alert\": \"Hello World\" } }"
   ```
 
-  or enter the following command if you are testing on Android or Browser:
+  or enter the following command if you are testing on Android or Browser (If you are running PhoneGap CLI 6.5.0 or earlier replace `--service fcm` with `--service gcm`):
 
   MacOS:
   ```sh
-  $ phonegap push --deviceID APA91bE1MmeTc92igNoi5OkDWUV --service gcm --payload '{ "data": { "title": "Hello", "message": "World"} }'
+  $ phonegap push --deviceID APA91bE1MmeTc92igNoi5OkDWUV --service fcm --payload '{ "data": { "title": "Hello", "message": "World"} }'
   ```
 
   Windows:
   ```sh
-  $ phonegap push --deviceID APA91bE1MmeTc92igNoi5OkDWUV --service gcm --payload "{ \"data\": { \"title\": \"Hello\", \"message\": \"World\"} }"
+  $ phonegap push --deviceID APA91bE1MmeTc92igNoi5OkDWUV --service fcm --payload "{ \"data\": { \"title\": \"Hello\", \"message\": \"World\"} }"
   ```
 
   replacing the deviceID with the one you received from the registration event in the previously.


### PR DESCRIPTION
…/AngularJS/Phonegap Developer App)

Can I get some eyes on this doc change. I want to make sure it makes sense. It will address the confusion reported in:

https://github.com/phonegap/phonegap-plugin-push/issues/1849
https://forums.adobe.com/thread/2356072