### PR TITLE
[Update 0-index.html.md] Removed references to phonegap.js

### DIFF
--- a/docs/4-phonegap-build/1-getting-started/0-index.html.md
+++ b/docs/4-phonegap-build/1-getting-started/0-index.html.md
@@ -18,7 +18,7 @@ PhoneGap and PhoneGap Build use an open packaging model that follows the [W3C Wi
 
 #### Don't include phonegap.js or plugin files
 
-PhoneGap Build will inject `phonegap.js`, `cordova.js` (identical sources), and any files required by your plugins, into the root of your www. This is because these files differ depending on the versions of PhoneGap and any plugins you are using. However you do still need to source phonegap.js or cordova.js (both are available and they are identical) from your html files.
+PhoneGap Build will inject `cordova.js` and any files required by your plugins, into the root of your www. This is because these files differ depending on the versions of PhoneGap and any plugins you are using. However you do still need to source cordova.js from your html files.
 
     <script src="cordova.js"></script>
 


### PR DESCRIPTION
If you reference `phonegap.js` (instead of `cordova.js`) you will get a warning in the console. This error comes from this bit of code which looks specifically for "/cordova.js" (which ironically is inside the phonegap.js file injected by Phonegap Build):

```javascript

function findCordovaPath() {
    var path = null;
    var scripts = document.getElementsByTagName('script');
    var term = '/cordova.js';
    for (var n = scripts.length-1; n>-1; n--) {
        var src = scripts[n].src.replace(/\?.*$/, ''); // Strip any query param (CB-6007).
        if (src.indexOf(term) == (src.length - term.length)) {
            path = src.substring(0, src.length - term.length) + '/';
            break;
        }
    }
    return path;
}
```
Unless someone changes the above code, the documentation should not mention phonegap.js at all because it generates a warning (which you can see from a remote debugging session). I have spent way too much time trying to figure out why I was getting this message...