### PR TITLE
add missing "android-" for version code

### DIFF
--- a/docs/4-phonegap-build/2-configuring/0-index.html.md
+++ b/docs/4-phonegap-build/2-configuring/0-index.html.md
@@ -71,7 +71,7 @@ All of the above fields are standard Cordova config.xml tags. For more detailed 
 <widget xmlns   = "http://www.w3.org/ns/widgets"
     xmlns:gap   = "http://phonegap.com/ns/1.0"
     id          = "com.phonegap.example"
-    versionCode = "10"
+    android-versionCode = "10"
     version     = "1.0.0" >
 
 <!-- versionCode is optional and Android only -->


### PR DESCRIPTION
Documentation seems to be inexact. Only writing versionCode="10" doesn't work.